### PR TITLE
Add environment overrides for storm CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# PythonSynapse
+
+This project provides a simple Python client for interacting with a Synapse Cortex instance. The `scripts` directory contains a command line interface for running Storm queries.
+
+## Environment variables
+
+The CLI reads connection settings from the environment. The following variables are supported:
+
+- `SYNAPSE_HOST`: Hostname of the Cortex instance (default: `localhost`).
+- `SYNAPSE_PORT`: Port of the Cortex instance (default: `443`).
+- `SYNAPSE_API_KEY`: Optional API key used for authentication.
+- `CORTEX_URL`: Full URL of the Cortex (for example `https://mycortex:4444`). When provided, the host and port are derived from this value and override `SYNAPSE_HOST` and `SYNAPSE_PORT`.
+- `OUTPUT_FILE`: Path to the file where Storm results are appended (default: `storm_results.json`).
+
+Load these variables using a `.env` file or your shell environment before running `storm_cli.py`.

--- a/scripts/storm_cli.py
+++ b/scripts/storm_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
@@ -13,8 +14,16 @@ def main() -> None:
     port = os.environ.get("SYNAPSE_PORT", "443")
     api_key = os.environ.get("SYNAPSE_API_KEY", "")
 
+    cortex_url = os.environ.get("CORTEX_URL")
+    if cortex_url:
+        parsed = urlparse(cortex_url)
+        if parsed.hostname:
+            host = parsed.hostname
+        if parsed.port:
+            port = str(parsed.port)
+
     client = SynapseClient(host=host, port=port, api_key=api_key)
-    output_file = Path("storm_results.json")
+    output_file = Path(os.environ.get("OUTPUT_FILE", "storm_results.json"))
 
     while True:
         query = input("storm> ").strip()


### PR DESCRIPTION
## Summary
- support `CORTEX_URL` and `OUTPUT_FILE` in `storm_cli.py`
- document environment variables used by the CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d286f7dc8327814afba9caf1ae2c