### PR TITLE
Add debug logging to CLI

### DIFF
--- a/scripts/storm_cli.py
+++ b/scripts/storm_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -8,6 +9,8 @@ from gosynapse.client import SynapseClient
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger("urllib3").setLevel(logging.DEBUG)
     load_dotenv()
     host = os.environ.get("SYNAPSE_HOST", "localhost")
     port = os.environ.get("SYNAPSE_PORT", "443")


### PR DESCRIPTION
## Summary
- enable debug logging in `storm_cli.py` to show request details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841faaf74588327a10a897e00ff93ae