### PR TITLE
Fix Storm query fallback

### DIFF
--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -107,8 +107,9 @@ class SynapseClient:
     ) -> tuple[List[InitData], List[Node], List[FiniData]]:
         url = self._url("/api/v1/storm")
         payload = {"query": storm_query, "opts": opts or {}, "stream": "jsonlines"}
-        # Synapse expects a POST request for executing Storm queries. Using GET
-        # results in a 404 on most deployments.
+        # Newer Synapse releases expect POST for Storm queries, but some
+        # deployments still use GET. Attempt a POST first and fall back to GET
+        # if the endpoint returns 404.
         resp = self.session.post(
             url,
             json=payload,
@@ -116,6 +117,14 @@ class SynapseClient:
             verify=False,
             stream=True,
         )
+        if resp.status_code == 404:
+            resp = self.session.get(
+                url,
+                json=payload,
+                headers=self._headers(),
+                verify=False,
+                stream=True,
+            )
         resp.raise_for_status()
         body = resp.content
         return parse_json_stream(body)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,51 @@
+import types
+import sys
+
+requests_stub = types.ModuleType("requests")
+class SessionStub:
+    def post(self, *a, **k):
+        pass
+
+    def get(self, *a, **k):
+        pass
+class HTTPError(Exception):
+    pass
+requests_stub.Session = SessionStub
+requests_stub.HTTPError = HTTPError
+sys.modules.setdefault("requests", requests_stub)
+
+from gosynapse.client import SynapseClient, InitData
+from gosynapse import client as client_module
+
+class FakeResponse:
+    def __init__(self, status_code, content=b''):
+        self.status_code = status_code
+        self.content = content
+    class HTTPError(Exception):
+        pass
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise self.HTTPError(f"{self.status_code} error")
+
+
+def test_storm_fallback_to_get(monkeypatch):
+    cli = SynapseClient(host='h', port='1')
+
+    post_resp = FakeResponse(404)
+    get_resp = FakeResponse(200, b'data')
+
+    monkeypatch.setattr(cli.session, 'post', lambda *a, **k: post_resp)
+    monkeypatch.setattr(cli.session, 'get', lambda *a, **k: get_resp)
+
+    result_tuple = ([InitData(tick=1, text='', abstick=0, hash='', task='')], [], [])
+    captured = {}
+    def fake_parse_json_stream(data):
+        captured['data'] = data
+        return result_tuple
+    monkeypatch.setattr(client_module, 'parse_json_stream', fake_parse_json_stream)
+
+    init, nodes, fini = cli.storm('foo')
+
+    assert init == result_tuple[0]
+    assert captured['data'] == b'data'


### PR DESCRIPTION
## Summary
- add GET fallback when POSTing storm queries returns 404
- cover fallback logic with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421ea780348327bf50bfc10d167e69