### PR TITLE
Align Python storm method with Go

### DIFF
--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -107,24 +107,15 @@ class SynapseClient:
     ) -> tuple[List[InitData], List[Node], List[FiniData]]:
         url = self._url("/api/v1/storm")
         payload = {"query": storm_query, "opts": opts or {}, "stream": "jsonlines"}
-        # Newer Synapse releases expect POST for Storm queries, but some
-        # deployments still use GET. Attempt a POST first and fall back to GET
-        # if the endpoint returns 404.
-        resp = self.session.post(
+        # The original Go client sends Storm queries using a GET request with the
+        # JSON payload in the body. Mirror that behaviour here for consistency.
+        resp = self.session.get(
             url,
             json=payload,
             headers=self._headers(),
             verify=False,
             stream=True,
         )
-        if resp.status_code == 404:
-            resp = self.session.get(
-                url,
-                json=payload,
-                headers=self._headers(),
-                verify=False,
-                stream=True,
-            )
         resp.raise_for_status()
         body = resp.content
         return parse_json_stream(body)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,13 +29,11 @@ class FakeResponse:
             raise self.HTTPError(f"{self.status_code} error")
 
 
-def test_storm_fallback_to_get(monkeypatch):
+def test_storm_uses_get(monkeypatch):
     cli = SynapseClient(host='h', port='1')
 
-    post_resp = FakeResponse(404)
     get_resp = FakeResponse(200, b'data')
 
-    monkeypatch.setattr(cli.session, 'post', lambda *a, **k: post_resp)
     monkeypatch.setattr(cli.session, 'get', lambda *a, **k: get_resp)
 
     result_tuple = ([InitData(tick=1, text='', abstick=0, hash='', task='')], [], [])


### PR DESCRIPTION
## Summary
- send Storm queries via GET like the original Go client
- update tests for the GET-only behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422028d0a88327925a412e57c95f5c