### PR TITLE
Add health check script and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ python scripts/storm_cli.py
 ```
 
 At the `storm>` prompt type your Storm queries. Type `exit` or `quit` to leave.
+
+## Health Check Utility
+
+A small helper script is provided to verify that your Synapse instance is reachable.
+Run it using the same environment variables as the CLI:
+
+```bash
+python scripts/health_check.py
+```
+
+The script will query the `/core/info` and `/active` endpoints and print the results as JSON. A non-zero exit code indicates the check failed.

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,4 @@
+from gosynapse.healthcheck import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -107,6 +107,8 @@ class SynapseClient:
     ) -> tuple[List[InitData], List[Node], List[FiniData]]:
         url = self._url("/api/v1/storm")
         payload = {"query": storm_query, "opts": opts or {}, "stream": "jsonlines"}
+        logger.debug("Storm request URL: %s", url)
+        logger.debug("Storm request payload: %s", payload)
         # The original Go client sends Storm queries using a GET request with the
         # JSON payload in the body. Mirror that behaviour here for consistency.
         resp = self.session.get(
@@ -116,8 +118,10 @@ class SynapseClient:
             verify=False,
             stream=True,
         )
+        logger.debug("Storm response status code: %s", resp.status_code)
         resp.raise_for_status()
         body = resp.content
+        logger.debug("Storm response body: %s", body.decode(errors="ignore"))
         return parse_json_stream(body)
 
     def storm_call(self, storm_query: str, opts: List[str]) -> GenericMessage:

--- a/src/gosynapse/healthcheck.py
+++ b/src/gosynapse/healthcheck.py
@@ -1,0 +1,35 @@
+import json
+import logging
+import os
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv() -> None:  # type: ignore
+        return None
+
+from .client import SynapseClient
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Perform a simple health check against a Synapse instance."""
+    logging.basicConfig(level=logging.DEBUG)
+    load_dotenv()
+    host = os.environ.get("SYNAPSE_HOST", "localhost")
+    port = os.environ.get("SYNAPSE_PORT", "443")
+    api_key = os.environ.get("SYNAPSE_API_KEY", "")
+    client = SynapseClient(host=host, port=port, api_key=api_key)
+    try:
+        core = client.core_info()
+        active = client.get_active()
+    except Exception as exc:  # requests.HTTPError or connection errors
+        logger.error("Health check failed: %s", exc)
+        return 1
+    print(json.dumps({"core_info": core.__dict__, "active": active.__dict__}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,29 @@
+import json
+import importlib.util
+
+from gosynapse.client import SynapseClient
+from gosynapse.healthcheck import main
+
+
+class Dummy:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_main_success(monkeypatch, capsys):
+    monkeypatch.setattr(SynapseClient, "core_info", lambda self: Dummy(status="ok", result={}))
+    monkeypatch.setattr(SynapseClient, "get_active", lambda self: Dummy(status="ok", result={}))
+    exit_code = main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert exit_code == 0
+    assert "core_info" in data
+    assert "active" in data
+
+
+def test_main_failure(monkeypatch):
+    def boom(*args, **kwargs):
+        raise Exception("fail")
+    monkeypatch.setattr(SynapseClient, "core_info", boom)
+    exit_code = main()
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- add extra debug logging in `SynapseClient.storm`
- implement `healthcheck` helper module with CLI wrapper
- document health check usage in README
- add tests for the health check utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422855191483278f9ecfa2d5952911