### PR TITLE
Add environment-based health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pytest
 ## Configuration
 
 `storm_cli.py` reads its configuration from environment variables which can be supplied via a `.env` file in the project root.
+The CLI now requires these variables to be present and will exit if any are missing.
 
 Example `.env`:
 
@@ -41,3 +42,16 @@ python scripts/storm_cli.py
 ```
 
 At the `storm>` prompt type your Storm queries. Type `exit` or `quit` to leave.
+
+## Health Check Utility
+
+A small helper script is provided to verify that your Synapse instance is reachable.
+It automatically loads settings from `.env` and checks both the `/active` endpoint
+and a trivial Storm call:
+
+```bash
+python scripts/health_check.py
+```
+
+The script will query the `/active` endpoint and run `return(1)` via `/storm/call`.
+It prints the JSON results and exits non-zero if anything fails.

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,4 @@
+from gosynapse.healthcheck import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/storm_cli.py
+++ b/scripts/storm_cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import logging
 from pathlib import Path
+import sys
 
 from dotenv import load_dotenv
 
@@ -11,11 +12,22 @@ from gosynapse.client import SynapseClient
 def main() -> None:
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger("urllib3").setLevel(logging.DEBUG)
-    load_dotenv()
-    host = os.environ.get("SYNAPSE_HOST", "localhost")
-    port = os.environ.get("SYNAPSE_PORT", "443")
-    api_key = os.environ.get("SYNAPSE_API_KEY", "")
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    host = os.environ.get("SYNAPSE_HOST", "").strip()
+    port = os.environ.get("SYNAPSE_PORT", "").strip()
+    api_key = os.environ.get("SYNAPSE_API_KEY", "").strip()
     view = os.environ.get("SYNAPSE_VIEW_ID")
+
+    missing = [name for name, val in [
+        ("SYNAPSE_HOST", host),
+        ("SYNAPSE_PORT", port),
+        ("SYNAPSE_API_KEY", api_key),
+    ] if not val]
+    if missing:
+        logging.error("Missing required environment variables: %s", ", ".join(missing))
+        sys.exit(1)
 
     client = SynapseClient(host=host, port=port, api_key=api_key)
     output_file = Path("storm_results.json")

--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -49,10 +49,16 @@ class SynapseClient:
         resp.raise_for_status()
 
     def get_active(self) -> Active:
+        """Return the Active dataclass, handling multiple response formats."""
         url = self._url("/api/v1/active")
         resp = self.session.get(url, headers=self._headers())
         resp.raise_for_status()
-        return Active(**resp.json())
+        data = resp.json()
+        if isinstance(data, dict) and "status" in data:
+            return Active(**data)
+        if isinstance(data, dict) and "active" in data:
+            return Active(status="ok", result={"active": data["active"]})
+        raise ValueError(f"Unexpected /active response: {data}")
 
     def get_users(self) -> Users:
         url = self._url("/api/v1/auth/users")
@@ -107,6 +113,8 @@ class SynapseClient:
     ) -> tuple[List[InitData], List[Node], List[FiniData]]:
         url = self._url("/api/v1/storm")
         payload = {"query": storm_query, "opts": opts or {}, "stream": "jsonlines"}
+        logger.debug("Storm request URL: %s", url)
+        logger.debug("Storm request payload: %s", payload)
         # The original Go client sends Storm queries using a GET request with the
         # JSON payload in the body. Mirror that behaviour here for consistency.
         resp = self.session.get(
@@ -116,8 +124,10 @@ class SynapseClient:
             verify=False,
             stream=True,
         )
+        logger.debug("Storm response status code: %s", resp.status_code)
         resp.raise_for_status()
         body = resp.content
+        logger.debug("Storm response body: %s", body.decode(errors="ignore"))
         return parse_json_stream(body)
 
     def storm_call(self, storm_query: str, opts: List[str]) -> GenericMessage:

--- a/src/gosynapse/healthcheck.py
+++ b/src/gosynapse/healthcheck.py
@@ -1,0 +1,71 @@
+import json
+import logging
+import os
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs) -> None:  # type: ignore
+        return None
+
+from .client import SynapseClient
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Perform a simple health check against a Synapse instance."""
+    logging.basicConfig(level=logging.DEBUG)
+    # Load .env from project root if present
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    host = os.environ.get("SYNAPSE_HOST", "").strip()
+    port = os.environ.get("SYNAPSE_PORT", "").strip()
+    api_key = os.environ.get("SYNAPSE_API_KEY", "").strip()
+
+    missing = [name for name, val in [
+        ("SYNAPSE_HOST", host),
+        ("SYNAPSE_PORT", port),
+        ("SYNAPSE_API_KEY", api_key),
+    ] if not val]
+    if missing:
+        logger.error("Missing required environment variables: %s", ", ".join(missing))
+        return 1
+
+    client = SynapseClient(host=host, port=port, api_key=api_key)
+
+    try:
+        active = client.get_active()
+    except Exception as exc:
+        logger.error("[/active] request failed: %s", exc)
+        return 1
+
+    if not isinstance(active.result, dict) or not active.result.get("active", False):
+        logger.error("[/active] returned inactive: %s", active.result)
+        return 1
+
+    try:
+        storm_resp = client.storm_call("return(1)", opts=[])
+    except Exception as exc:
+        logger.error("[/storm/call] request failed: %s", exc)
+        return 1
+
+    result = storm_resp.result
+    try:
+        ok = int(result) == 1
+    except Exception:
+        ok = False
+
+    if not ok:
+        logger.error("[/storm/call] unexpected result: %s", result)
+        return 1
+
+    print(json.dumps({"active": active.result, "storm_call_result": result}))
+    logger.info("All health checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,35 @@
+import json
+import importlib.util
+
+from gosynapse.client import SynapseClient
+from gosynapse.healthcheck import main
+
+
+class Dummy:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_main_success(monkeypatch, capsys):
+    monkeypatch.setenv("SYNAPSE_HOST", "host")
+    monkeypatch.setenv("SYNAPSE_PORT", "443")
+    monkeypatch.setenv("SYNAPSE_API_KEY", "key")
+    monkeypatch.setattr(SynapseClient, "get_active", lambda self: Dummy(status="ok", result={"active": True}))
+    monkeypatch.setattr(SynapseClient, "storm_call", lambda self, q, opts: Dummy(status="ok", result=1))
+    exit_code = main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert exit_code == 0
+    assert data["active"]["active"] is True
+    assert data["storm_call_result"] == 1
+
+
+def test_main_failure(monkeypatch):
+    monkeypatch.setenv("SYNAPSE_HOST", "host")
+    monkeypatch.setenv("SYNAPSE_PORT", "443")
+    monkeypatch.setenv("SYNAPSE_API_KEY", "key")
+    def boom(*args, **kwargs):
+        raise Exception("fail")
+    monkeypatch.setattr(SynapseClient, "get_active", boom)
+    exit_code = main()
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- check `/active` and `/storm/call` in the health check
- enforce presence of env vars from `.env`
- handle different `/active` JSON responses
- test healthcheck behaviour
- require env vars for CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68422855191483278f9ecfa2d5952911