### PR TITLE
Fix storm query endpoint

### DIFF
--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -109,9 +109,10 @@ class SynapseClient:
         payload = {"query": storm_query, "opts": opts or {}, "stream": "jsonlines"}
         logger.debug("Storm request URL: %s", url)
         logger.debug("Storm request payload: %s", payload)
-        # The original Go client sends Storm queries using a GET request with the
-        # JSON payload in the body. Mirror that behaviour here for consistency.
-        resp = self.session.get(
+        # Use POST for Storm queries. Some Cortex deployments do not expose the
+        # legacy GET /storm endpoint, so using POST ensures broader
+        # compatibility while still returning the streaming JSON lines.
+        resp = self.session.post(
             url,
             json=payload,
             headers=self._headers(),

--- a/src/gosynapse/healthcheck.py
+++ b/src/gosynapse/healthcheck.py
@@ -15,9 +15,28 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from dotenv import load_dotenv, find_dotenv
-from urllib3.exceptions import InsecureRequestWarning
-import urllib3
+try:
+    from dotenv import load_dotenv, find_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs):
+        """Fallback no-op if python-dotenv is not installed."""
+        return False
+
+    def find_dotenv(*_args, **_kwargs) -> str:
+        return ""
+try:
+    from urllib3.exceptions import InsecureRequestWarning
+    import urllib3
+except Exception:  # pragma: no cover - optional dependency
+    class InsecureRequestWarning(Exception):
+        pass
+
+    class Dummy:
+        @staticmethod
+        def disable_warnings(*_a, **_k):
+            pass
+
+    urllib3 = Dummy()
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,10 @@ class HTTPError(Exception):
     pass
 requests_stub.Session = SessionStub
 requests_stub.HTTPError = HTTPError
+def _dummy(*a, **k):
+    raise NotImplementedError
+requests_stub.get = _dummy
+requests_stub.post = _dummy
 sys.modules.setdefault("requests", requests_stub)
 
 from gosynapse.client import SynapseClient, InitData
@@ -29,12 +33,12 @@ class FakeResponse:
             raise self.HTTPError(f"{self.status_code} error")
 
 
-def test_storm_uses_get(monkeypatch):
+def test_storm_uses_post(monkeypatch):
     cli = SynapseClient(host='h', port='1')
 
-    get_resp = FakeResponse(200, b'data')
+    post_resp = FakeResponse(200, b'data')
 
-    monkeypatch.setattr(cli.session, 'get', lambda *a, **k: get_resp)
+    monkeypatch.setattr(cli.session, 'post', lambda *a, **k: post_resp)
 
     result_tuple = ([InitData(tick=1, text='', abstick=0, hash='', task='')], [], [])
     captured = {}


### PR DESCRIPTION
## Summary
- send POST requests to `/api/v1/storm` for Storm queries
- make `healthcheck` robust when optional dependencies are missing
- adjust tests to expect POST behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a24b4f08327a0234239d431d654