### PR TITLE
Handle storm print output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ python scripts/storm_cli.py
 
 At the `storm>` prompt type your Storm queries. Type `exit` or `quit` to leave.
 
+Each command's output is appended to `storm_results.json`. The file now
+records any text printed by the Cortex under a `"print"` key. Counts from
+queries like `| count` appear here even though they don't emit nodes.
+If you do not see the `"print"` list, ensure the CLI is using the local
+`gosynapse` code by running `pip install -e .` or by setting
+`PYTHONPATH=src` before launching the script.
+
 ## Health Check Utility
 
 `scripts/health_check.py` verifies connectivity to your Cortex. It loads the `.env`

--- a/scripts/storm_cli.py
+++ b/scripts/storm_cli.py
@@ -30,7 +30,7 @@ def main() -> None:
             break
         opts = {"view": view} if view else None
         try:
-            init, nodes, fini = client.storm(query, opts=opts)
+            init, nodes, fini, prints = client.storm(query, opts=opts)
         except Exception as exc:  # requests.HTTPError or connection errors
             logging.error("Storm query failed: %s", exc)
             continue
@@ -38,6 +38,7 @@ def main() -> None:
             "init": [asdict(i) for i in init],
             "nodes": [asdict(n) for n in nodes],
             "fini": [asdict(f) for f in fini],
+            "print": [asdict(p) for p in prints],
         }
         with output_file.open("a", encoding="utf-8") as f:
             json.dump(result, f)

--- a/src/gosynapse/__init__.py
+++ b/src/gosynapse/__init__.py
@@ -9,7 +9,7 @@ try:
 except ModuleNotFoundError:  # requests may be missing in some environments
     SynapseClient = object()
 
-from .parse import parse_json_stream, InitData, Node, FiniData  # noqa: E402
+from .parse import parse_json_stream, InitData, Node, FiniData, PrintData  # noqa: E402
 from .types import (  # noqa: E402
     Users,
     Roles,
@@ -25,6 +25,7 @@ __all__ = [
     "InitData",
     "Node",
     "FiniData",
+    "PrintData",
     "Users",
     "Roles",
     "Active",

--- a/src/gosynapse/client.py
+++ b/src/gosynapse/client.py
@@ -14,7 +14,7 @@ from .types import (
     CortexModel,
     AxonDelete,
 )
-from .parse import parse_json_stream, InitData, Node, FiniData
+from .parse import parse_json_stream, InitData, Node, FiniData, PrintData
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class SynapseClient:
 
     def storm(
         self, storm_query: str, opts: Optional[Dict[str, str]] = None
-    ) -> tuple[List[InitData], List[Node], List[FiniData]]:
+    ) -> tuple[List[InitData], List[Node], List[FiniData], List[PrintData]]:
         url = self._url("/api/v1/storm")
         payload = {
             "query": storm_query,

--- a/src/gosynapse/parse.py
+++ b/src/gosynapse/parse.py
@@ -39,14 +39,19 @@ class FiniData:
     count: int
 
 
-def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[FiniData]]:
+@dataclass
+class PrintData:
+    mesg: str
+
+
+def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[FiniData], List[PrintData]]:
     """Parse a stream of JSON messages produced by Synapse.
 
     Args:
         raw: Raw bytes from the server.
 
     Returns:
-        A tuple of lists: (init messages, nodes, fini messages).
+        A tuple of lists: (init messages, nodes, fini messages, print messages).
     """
     reader = BytesIO(raw)
     decoder = json.JSONDecoder()
@@ -55,6 +60,7 @@ def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[Fini
     init_items: List[InitData] = []
     nodes: List[Node] = []
     fini_items: List[FiniData] = []
+    print_items: List[PrintData] = []
 
     for line in reader.readlines():
         buffer += line.decode()
@@ -80,6 +86,8 @@ def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[Fini
                     node_pairs.append([str(x) for x in pair])
             info = NodeData(**payload[1])
             nodes.append(Node(key="node", data=node_pairs, info=info))
+        elif key == "print":
+            print_items.append(PrintData(**payload))
         elif key == "fini":
             fini_items.append(FiniData(**payload))
-    return init_items, nodes, fini_items
+    return init_items, nodes, fini_items, print_items

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ def test_storm_post_fallback_to_get(monkeypatch):
     monkeypatch.setattr(cli.session, "post", lambda *a, **k: post_resp)
     monkeypatch.setattr(cli.session, "get", lambda *a, **k: get_resp)
 
-    result_tuple = ([InitData(tick=1, text="", abstick=0, hash="", task="")], [], [])
+    result_tuple = ([InitData(tick=1, text="", abstick=0, hash="", task="")], [], [], [])
     captured = {}
 
     def fake_parse_json_stream(data):
@@ -52,7 +52,8 @@ def test_storm_post_fallback_to_get(monkeypatch):
 
     monkeypatch.setattr(client_module, "parse_json_stream", fake_parse_json_stream)
 
-    init, nodes, fini = cli.storm("foo")
+    init, nodes, fini, prints = cli.storm("foo")
 
     assert init == result_tuple[0]
+    assert prints == result_tuple[3]
     assert captured["data"] == b"data"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,11 +1,21 @@
-from gosynapse.parse import parse_json_stream, InitData, FiniData
+from gosynapse.parse import parse_json_stream, InitData, FiniData, PrintData
 
 
 def test_parse_json_stream_simple():
     data = b'["init", {"tick": 1, "text": "t", "abstick": 2, "hash": "h", "task": "tsk"}]\n' \
            b'["node", [[["foo", "bar"]], {"iden": "id", "tags": {}, "props": {}, "tagprops": {}, "nodedata": {}, "path": {}}]]\n' \
            b'["fini", {"tock": 1, "abstock": 1, "took": 1, "count": 1}]\n'
-    init, nodes, fini = parse_json_stream(data)
+    init, nodes, fini, prints = parse_json_stream(data)
     assert init == [InitData(tick=1, text="t", abstick=2, hash="h", task="tsk")]
     assert nodes[0].data == [["foo", "bar"]]
     assert fini == [FiniData(tock=1, abstock=1, took=1, count=1)]
+    assert prints == []
+
+
+def test_parse_json_stream_print():
+    data = (
+        b'["print", {"mesg": "hello"}]\n'
+        b'["fini", {"tock": 1, "abstock": 1, "took": 1, "count": 0}]\n'
+    )
+    init, nodes, fini, prints = parse_json_stream(data)
+    assert prints == [PrintData(mesg="hello")]


### PR DESCRIPTION
## Summary
- capture `print` events from storm queries
- expose print data in CLI results
- test JSON parsing of print messages
- document how `storm_results.json` includes prints and how to ensure the CLI uses the local package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849df59d6348327b2f4623a0c60a97a