### PR TITLE
Improve storm debug logging

### DIFF
--- a/scripts/storm_cli.py
+++ b/scripts/storm_cli.py
@@ -41,6 +41,8 @@ def main() -> None:
         except Exception as exc:  # requests.HTTPError or connection errors
             logging.error("Storm query failed: %s", exc)
             continue
+        logging.debug("Storm prints: %s", prints)
+        logging.debug("Storm nodes count: %s", len(nodes))
         result = {
             "init": [asdict(i) for i in init],
             "nodes": [asdict(n) for n in nodes],

--- a/src/gosynapse/parse.py
+++ b/src/gosynapse/parse.py
@@ -63,7 +63,8 @@ def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[Fini
     print_items: List[PrintData] = []
 
     for line in reader.readlines():
-        buffer += line.decode()
+        decoded = line.decode()
+        buffer += decoded
         buffer = buffer.strip()
         if not buffer:
             continue
@@ -71,9 +72,11 @@ def parse_json_stream(raw: bytes) -> Tuple[List[InitData], List[Node], List[Fini
             data, index = decoder.raw_decode(buffer)
             buffer = buffer[index:].lstrip()
         except json.JSONDecodeError:
+            logger.debug("Failed to decode JSON line: %s", decoded.strip())
             continue
 
         if not isinstance(data, list) or not data:
+            logger.debug("Unexpected storm message: %s", data)
             continue
         key = data[0]
         payload = data[1]


### PR DESCRIPTION
## Summary
- log decode failures and unexpected messages in `parse_json_stream`
- add debug logs in `storm_cli.py` to show returned print messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0be020908327a79ed512cffc5c43